### PR TITLE
added a bunch of links to the `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# codewithfriends.dev
-Website at https://codewithfriends.dev for humans and computers to commune and co-operate.
+# [codewithfriends.dev](//codewithfriends.dev)
+[Website](//codewithfriends.dev) for humans and computers to commune and co-operate.
 
 ## Mockup
-https://www.figma.com/file/g86E9GBhrhIHwN01ZZE8lF/Code-With-Friends-Front-Page?node-id=0-1&t=LPycYmpysE7xLxBC-0
+
+* [Figma](https://www.figma.com/file/g86E9GBhrhIHwN01ZZE8lF/Code-With-Friends-Front-Page?node-id=0-1&t=LPycYmpysE7xLxBC-0)
 
 ## Meetings
 
@@ -10,22 +11,22 @@ https://www.figma.com/file/g86E9GBhrhIHwN01ZZE8lF/Code-With-Friends-Front-Page?n
 
 ## Official Communication Channel
 
-* Discord - https://discord.gg/uVgcDMtC
+* [Discord](//discord.gg/uVgcDMtC)
 
 ## Development Environment Setup
 
-* Windows - [Click here for instructions to setup your Windows machine](https://github.com/DetroitCodeWithFriends/codewithfriends.dev/blob/main/setup-windows.md)
+* [Windows](setup-windows.md)
 * Mac/Linux - 
 
-## Current Members And Their Interests/Proposed Projects
+## Current Members and Their Interests/Proposed Projects
 
 |Members |Interests/Proposed Projects |
 --- | --- |
-|@dysbulic 🐙#3391|distributed / collaborative file system using the properties of graph databases to achieve new kinds of queries and fast performance|
-|@imari8#5342|reading app|
-|@naltroc#6951|deep mathematical structures underlying the qualitative and ineffable beauty of music, whose appreciation may extend to animalia, plantae, and funga|
-|@pc.su#0211|generative art through p5.js and better understand how technology can generate beauty, beauty can generate products, and how groups of humans can help co-create and live processes and products|
-|@CCHUN#0356|multiplayer chess server with tutoring features|
-|@Brian - R#3947|experiment with using databases to solve the problems of distributed real-time wildlife cameras and their specific needs for computer vision|
-|@JeffH#7543|leisurely fun API project like getting the r/ProgrammerHumor subReddit content into our own format. Daily r/ProgrammersHumor feed to offer subscribers a laugh, using Reddit API, Twilio/SMS integration|
-|@life-long-learner#0653|CodeWithFriends live coding interface, using Jitsi, XTERM and CodeSandbox|
+|[@dysbulic 🐙](//discordapp.com/users/308430775684956161)|<ul><li>[𝔐𝔦̈𝔪𝔦𝔰](//mimisb.run): distributed / collaborative file system using the [Neo4j](//neo4j.com) graph databases to achieve new kinds of queries and fast performance</li><li>[’Chievemints](//chiev.es): NFT minting and display site using NFTs within the system to token gate the permissions on others</li></ul>|
+|[@imari8](//discordapp.com/users/883139012544569416)|reading app|
+|[@naltroc](//discordapp.com/users/568987914986455040)|deep mathematical structures underlying the qualitative and ineffable beauty of music, whose appreciation may extend to animalia, plantae, and funga|
+|[@pc.su](//discordapp.com/users/704126768927342592)|generative art through [p5.js](//p5js.org) and better understand how technology can generate beauty, beauty can generate products, and how groups of humans can help co-create and live processes and products|
+|[@CCHUN](//discordapp.com/users/628979858927779851)|multiplayer chess server with tutoring features|
+|[@Brian - R](//discordapp.com/users/830490232599871529)|experiment with [ChirpStack](//chirpstack.io) & [Postgresql](//postgres.org) to solve the problems of distributed real-time wildlife cameras and their specific needs for computer vision|
+|[@JeffH](//discordapp.com/users/286137835814125570)|leisurely fun API project like getting the [r/ProgrammerHumor subReddit](//reddit.com/r/ProgrammerHumor) content into our own format. Daily r/ProgrammersHumor feed to offer subscribers a laugh, using Reddit API, [Twilio](//twilio.com)/SMS integration|
+|[@life-long-learner](//discordapp.com/users/827415572111032350)|CodeWithFriends live coding interface, using [Jitsi](//jitsi.org), [tmux](//github.com/tmux/tmux/wiki), XTerm and [CodeSandbox](//codesandbox.io)|


### PR DESCRIPTION
I changed various URLs and appropriate text to Markdown links.

The only changes I could imagine being controversial is I linked everyone's Discord username to their profile on Discord's site & removed the `#xxxx` number from usernames on the page. If someone would like to message someone, they'd just click the link then click the “Message” button.